### PR TITLE
SD Performance Tweaks

### DIFF
--- a/Firmware/Hal/lpc_chip_43xx/inc/sdmmc.h
+++ b/Firmware/Hal/lpc_chip_43xx/inc/sdmmc.h
@@ -270,6 +270,10 @@ typedef struct {
 #define SD_SEND_RELATIVE_ADDR     3		/* ac                      R6  */
 #define SD_CMD8                   8		/* bcr  [31:0]  OCR        R3  */
 
+/* class 10 */
+#define SD_SWITCH_FUNC            6		/* adtc [31]    mode       R1   */
+                                  		/*      [3:0]   access mode     */
+
 /* Application commands */
 #define SD_APP_SET_BUS_WIDTH      6		/* ac   [1:0]   bus width  R1   */
 #define SD_APP_OP_COND           41		/* bcr  [31:0]  OCR        R1 (R4)  */
@@ -448,9 +452,3 @@ typedef struct {
  */
 
 #endif /* __SDMMC_H */
-
-
-
-
-
-

--- a/Firmware/Hal/lpc_chip_43xx/inc/sdmmc_18xx_43xx.h
+++ b/Firmware/Hal/lpc_chip_43xx/inc/sdmmc_18xx_43xx.h
@@ -81,6 +81,7 @@ extern "C" {
 #define CMD_STOP            CMD(MMC_STOP_TRANSMISSION, 1) | CMD_BIT_BUSY
 #define CMD_WRITE_SINGLE    CMD(MMC_WRITE_BLOCK, 1) | CMD_BIT_DATA | CMD_BIT_WRITE
 #define CMD_WRITE_MULTIPLE  CMD(MMC_WRITE_MULTIPLE_BLOCK, 1) | CMD_BIT_DATA | CMD_BIT_WRITE | CMD_BIT_AUTO_STOP
+#define CMD_SD_SWITCH_FUNC  CMD(SD_SWITCH_FUNC, 1) | CMD_BIT_DATA
 
 /* Card specific setup data */
 typedef struct _mci_card_struct {
@@ -149,9 +150,3 @@ int32_t Chip_SDMMC_WriteBlocks(LPC_SDMMC_T *pSDMMC, void *buffer, int32_t start_
 #endif
 
 #endif /* __SDMMC_18XX_43XX_H_ */
-
-
-
-
-
-

--- a/Firmware/Hal/lpc_chip_43xx/src/sdmmc_18xx_43xx.c
+++ b/Firmware/Hal/lpc_chip_43xx/src/sdmmc_18xx_43xx.c
@@ -31,6 +31,7 @@
 
 #include "chip.h"
 #include "string.h"
+#include <assert.h>
 
 /*****************************************************************************
  * Macros to enable/disable Performance Tweaks
@@ -39,6 +40,10 @@
 /* Setting to 1 will only set the SDIF clock as needed. */
 /* Setting to 0 will set it before each command is sent, usually to its current rate. */
 #define SDIF_CLOCK_OPTIMIZE 1
+
+/* Setting to 1 enables switching into 50MHz high speed SD card mode. */
+/* Setting to 0 leaves it at the default 25MHz speed mode. */
+#define ENABLE_HIGH_SPEED 1
 
 /*****************************************************************************
  * Private types/enumerations/variables
@@ -173,6 +178,41 @@ static int32_t sdmmc_execute_command(LPC_SDMMC_T *pSDMMC, uint32_t cmd, uint32_t
 	return 0;
 }
 
+/* Function to extract bits from a multi-byte array, common in SD response data. */
+uint32_t extractBits(const uint8_t* p, size_t size, uint32_t lowBit, uint32_t highBit)
+{
+    uint32_t bitCount = highBit - lowBit + 1;
+    int      lowByte = (size-1) - (lowBit >> 3);
+    int      highByte = (size-1) - (highBit >> 3);
+    uint32_t val = 0;
+
+    assert ( bitCount <= 32 );
+    assert ( lowByte >= 0 );
+    assert ( highByte >= 0 );
+
+    uint32_t bitsLeft = bitCount;
+    uint32_t bitSrcOffset = lowBit & 7;
+    uint32_t bitDestOffset = 0;
+    for (int i = lowByte ; i >= highByte ; i--)
+    {
+        uint32_t bitsFromByte = 8 - bitSrcOffset;
+        if (bitsFromByte > bitsLeft)
+        {
+            bitsFromByte = bitsLeft;
+        }
+        uint32_t byteMask = (1 << bitsLeft) - 1;
+
+        val |= ((p[i] >> bitSrcOffset) & byteMask) << bitDestOffset;
+
+        bitSrcOffset = 0;
+        bitDestOffset += bitsFromByte;
+        bitsLeft -= bitsFromByte;
+    }
+    assert ( bitsLeft == 0 );
+
+    return val;
+}
+
 /* Checks whether card is acquired properly or not */
 static int32_t prv_card_acquired(void)
 {
@@ -299,10 +339,29 @@ static int32_t prv_set_trans_state(LPC_SDMMC_T *pSDMMC)
 	return 0;
 }
 
-/* Sets card data width and block size */
+/* Sets card speed, data width, and block size */
 static int32_t prv_set_card_params(LPC_SDMMC_T *pSDMMC)
 {
+    int     isHighSpeedEnabled = 0;
 	int32_t status;
+
+    /* Attempt to bump the card up to high speed. */
+	if (ENABLE_HIGH_SPEED && g_card_info->card_info.card_type & CARD_TYPE_SD) {
+        const uint32_t setMode = 1 << 31;
+        const uint32_t highSpeedAccessMode = 1 << 0;
+        uint32_t switchFunctionStatus[512 / 8 / sizeof(uint32_t)];
+
+        Chip_SDIF_SetBlkSizeByteCnt(pSDMMC, sizeof(switchFunctionStatus));
+        Chip_SDIF_DmaSetup(pSDMMC,
+                           &g_card_info->sdif_dev,
+                           (uint32_t)&switchFunctionStatus[0],
+                           sizeof(switchFunctionStatus));
+		status = sdmmc_execute_command(pSDMMC, CMD_SD_SWITCH_FUNC, setMode | highSpeedAccessMode, MCI_INT_DATA_OVER);
+		if (status == 0 && extractBits(&switchFunctionStatus[0], sizeof(switchFunctionStatus), 376, 379) == 1) {
+			/* Successfully enabled high speed mode. */
+            isHighSpeedEnabled = 1;
+		}
+	}
 
 #if SDIO_BUS_WIDTH > 1
 	if (g_card_info->card_info.card_type & CARD_TYPE_SD) {
@@ -317,6 +376,12 @@ static int32_t prv_set_card_params(LPC_SDMMC_T *pSDMMC)
 #elif SDIO_BUS_WIDTH > 4
 #error 8-bit mode not supported yet!
 #endif
+
+    /* At least 8 clocks were used to send set-width command so can switch to high speed rate for future commands. */
+    if (isHighSpeedEnabled) {
+        /* Start using a 50MHz high speed clock from now on. */
+        g_card_info->card_info.speed = 50000000;
+    }
 
 	/* set block length */
 	Chip_SDIF_SetBlkSize(pSDMMC, MMC_SECTOR_SIZE);


### PR DESCRIPTION
Maximum read speed seen with these driver changes was **13MB/sec** when using **64k reads** but as checked in with **16k reads**, the maximum read rate seen was **11.7MB/sec** on a SanDisk Extreme U3 speed class card.

In general write performance numbers aren't very consistent from run to run but read rates are. I did get consistent write performance measurements between runs completed immediately after a format. When I used the SDFormatter utility downloaded from the SD site, I saw a 25% improvement in 4k/16k writes as compared to after being formatted with Ubuntu. I think that the proper way to format SD cards requires knowledge of the card's Allocation Unit (AU) size to know where to optimally place things like the FAT and root directory. This isn't a Linux specific issue though! I have seen macOS formatting have similar impacts on write performance in the past.

This PR includes 3 commits, 2 are performance tweaks in the SD driver and the other is a test case change:
* Only update the SPDIF clock when it needs to be changed away from its current value. It used to do it before every SD command was sent and involves quite a bit of math.
* Switch the SD bus from the 25MHz default speed to 50MHz high speed on cards that support this faster rate.
* I bumped the global test buffer up to 16k and broke the SD performance test code out so that I could run it 3 times with read/writes of 1k, 4k and 16k in size.

There are macros at the top of sdmmc_18xx_43xx.c which can be used to disable either of these optimizations if you expect that they are causing reliability issues and you want to quickly disable and verify that they are really the cause.

I did try sending the ACMD23 command to pre-erase the blocks when using multi-block write but in these tests it ended up decreasing the performance and not increasing it so I didn't include it in this PR.