### PR TITLE
SD driver aggressively rounds CLKDIV up

### DIFF
--- a/Firmware/Hal/lpc_chip_43xx/src/sdif_18xx_43xx.c
+++ b/Firmware/Hal/lpc_chip_43xx/src/sdif_18xx_43xx.c
@@ -53,7 +53,7 @@ void Chip_SDIF_Init(LPC_SDMMC_T *pSDMMC)
 {
     /* Enable SDIO module clock */
 	Chip_Clock_EnableOpts(CLK_MX_SDIO, true, true, 1);
-	
+
     /* Software reset */
 	pSDMMC->BMOD = MCI_BMOD_SWR;
 
@@ -130,7 +130,7 @@ void Chip_SDIF_SetClock(LPC_SDMMC_T *pSDMMC, uint32_t clk_rate, uint32_t speed)
 	/* compute SD/MMC clock dividers */
 	uint32_t div;
 
-	div = ((clk_rate / speed) + 2) >> 1;
+	div = ((clk_rate / speed) + 1) >> 1;
 
 	if ((div == pSDMMC->CLKDIV) && pSDMMC->CLKENA) {
 		return;	/* Closest speed is already set */


### PR DESCRIPTION
This meant that trying to set the SD clock rate to 50MHz resulted in a
clock rate of 204/6 = 34MHz instead of the desired 50MHz. The way I
modified the code will result in SD clock rates which are a little
high:
  51MHz for high speed
  25.5MHz for the default speed
Hopefully that will be ok for most cards.

I hacked in a way to perform a 4MB read and it obtained a rate of
24.5MB/sec which was very close to the maximum of 25MB/sec for high
speed SD. It got my 16K reads up to 15.5MB/sec which isn't too bad
either.