### PR TITLE
Minor SD fixes

### DIFF
--- a/Firmware/Hal/lpc_chip_43xx/src/sdif_18xx_43xx.c
+++ b/Firmware/Hal/lpc_chip_43xx/src/sdif_18xx_43xx.c
@@ -31,6 +31,7 @@
 
 #include "chip.h"
 #include "string.h"
+#include <assert.h>
 
 /*****************************************************************************
  * Private types/enumerations/variables
@@ -176,6 +177,9 @@ void Chip_SDIF_DmaSetup(LPC_SDMMC_T *pSDMMC, sdif_device *psdif_dev, uint32_t ad
 {
 	int i = 0;
 	uint32_t ctrl, maxs;
+
+	/* DMA chain is only sized to read a maximum of 64k */
+	assert(size <= 64 * 1024);
 
 	/* Reset DMA */
 	pSDMMC->CTRL |= MCI_CTRL_DMA_RESET | MCI_CTRL_FIFO_RESET;

--- a/Firmware/Hal/sdmmc/src/fs_mci.c
+++ b/Firmware/Hal/sdmmc/src/fs_mci.c
@@ -208,6 +208,9 @@ DRESULT disk_read(BYTE drv, BYTE *buff, DWORD sector, UINT count)
 		// unaligned buffer is not ok
 		int32_t cbRead = count * MMC_SECTOR_SIZE;
 		uint32_t *aligned_buffer = (uint32_t *)malloc(cbRead);
+		if (!aligned_buffer) {
+			return RES_ERROR;
+		}
 		int ret= FSMCI_CardReadSectors(hCard, aligned_buffer, sector, count);
 		memcpy(buff, aligned_buffer, cbRead);
 		free(aligned_buffer);
@@ -251,6 +254,9 @@ DRESULT disk_write(BYTE drv, const BYTE *buff, DWORD sector, UINT count)
 		// unaligned buffer is not ok
 		int32_t cbWrite = count * MMC_SECTOR_SIZE;
 		uint32_t *aligned_buffer = (uint32_t *)malloc(cbWrite);
+		if (!aligned_buffer) {
+			return RES_ERROR;
+		}
 		memcpy(aligned_buffer, buff, cbWrite);
 		int ret= FSMCI_CardWriteSectors(hCard, aligned_buffer, sector, count);
 		free(aligned_buffer);


### PR DESCRIPTION
* Fail SD read/write if malloc() fails
* Assert size passed into Chip_SDIF_DmaSetup() <= 64k